### PR TITLE
Random fontFamily equal for all fonts

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -125,10 +125,10 @@
     Not-borrowed-code starts here!
 
    **/
-  function Font() {}
-
-  // if this is not specified, a random name is used
-  Font.prototype.fontFamily = "fjs" + (999999 * Math.random() | 0);
+  function Font() {
+    // if this is not specified, a random name is used
+    this.fontFamily = "fjs" + (999999 * Math.random() | 0);
+  }
 
   // the font resource URL
   Font.prototype.url = "";


### PR DESCRIPTION
When using Font.js with multiple fonts without settings the fontFamily, since the random fontFamily is set directly on the prototype, all objects and in turn styleNode's will have the same font-family. This is not optimal if your font's are actually not in the same family.

This commit will set a new random fontFamily for er each new Font() object. I'm not sure about the intent of the random title, but this way we can at least tell them apart.
