### PR TITLE
The Font object has onerror(), not error().

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -632,9 +632,8 @@
    * separately.
    */
   Font.prototype.measureText = function (textString, fontSize) {
-    // error shortcut
     if (!this.loaded) {
-      this.error("measureText() was called while the font was not yet loaded");
+      this.onerror("measureText() was called while the font was not yet loaded");
       return false;
     }
 


### PR DESCRIPTION
If measure text is called before the font is loaded, it attempts to output an error message, but it calls the non-existant error method instead of calling onerror. This fixes that call.
