### PR TITLE
Listen for network level errors for remote fonts.

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -599,6 +599,9 @@
         font.onerror("Error downloading font resource from "+font.url);
       }
     };
+    xhr.onerror = function (evt) {
+      font.onerror("Error downloading font resource from "+font.url);
+    };
     xhr.send(null);
   };
 


### PR DESCRIPTION
This will make sure that the onerror callback gets fired for network level errors that occur when there is a network level error (wrong url, can't find asset).
