### PR TITLE
Fix faulty width calculation

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -204,7 +204,7 @@
       this.onerror("Requested system font '"+this.fontFamily+"' could not be loaded (it may not be installed).");
       return;
     }
-    var width = getComputedStyle(target, null).getPropertyValue("width").replace("px", '');
+    var width = getComputedStyle(target, null).getPropertyValue("width").replace("px", '').replace(",",'.') ;
     // font has finished loading - remove the zero-width and
     // validation paragraph, but leave the actual font stylesheet (mark);
     if (width > 0) {


### PR DESCRIPTION
Sometimes the getPropertyValue("width") returns values ike "89,123" which breaks the if condition "if(width > 0". Therefore the "," gets replaced by a "."