### PR TITLE
Unquoted format causing unwanted font behavior and rendering

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -631,7 +631,7 @@
     var fixedIEUrl = this.url.replace('.ttf', '.eot');
     var styletext = "@font-face {\n";
        styletext += "  font-family: '" + this.fontFamily + "';\n";
-       styletext += "  src: url('" + fixedIEUrl + "') format(eot), url('" + this.url + "') format('" + this.format + "');\n";
+       styletext += "  src: url('" + fixedIEUrl + "') format('eot'), url('" + this.url + "') format('" + this.format + "');\n";
        styletext += "}";
     this.styleNode.innerHTML = styletext;
     return this.styleNode;


### PR DESCRIPTION
Adds quotes to eot format. Unquoted format causes unwanted font rendering issues. This adds in the quotes to the format, a la the other formats in same line of code.