### PR TITLE
Add option to load font through base64 string

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -100,10 +100,9 @@ class Font extends EventManager {
      * @param {String} filename The filename when URL is a base64 string
      */
     async loadFont(url, filename) {
-        const type = getFontCSSFormat(filename || url);
         fetch(url)
         .then(response => checkFetchResponseStatus(response) && response.arrayBuffer())
-        .then(buffer => this.fromDataBuffer(buffer, type))
+        .then(buffer => this.fromDataBuffer(buffer, filename || url))
         .catch(err => {
             const evt = new Event(`error`, err, `Failed to load font at ${filename || url}`);
             this.dispatch(evt);
@@ -116,7 +115,8 @@ class Font extends EventManager {
      *
      * @param {Buffer} buffer The binary data associated with this font.
      */
-    async fromDataBuffer(buffer, type) {
+    async fromDataBuffer(buffer, filenameOrUrl) {
+        const type = getFontCSSFormat(filenameOrUrl);
         this.fontData = new DataView(buffer); // Because we want to enforce Big Endian everywhere
         await this.parseBasicData(type);
         const evt = new Event("load", { font: this });

--- a/Font.js
+++ b/Font.js
@@ -4,6 +4,20 @@ import { Event, EventManager } from "./src/eventing.js";
 import { SFNT, WOFF, WOFF2 } from "./src/opentype/index.js";
 import { loadTableClasses } from "./src/opentype/tables/createTable.js";
 
+const PERMITTED_TYPES = [
+    `ttf`,
+    `otf`,
+    `woff`,
+    `woff2`,
+];
+const ILLEGAL_TYPES = [
+    `eot`,
+    `svg`,
+    `fon`,
+    `ttc`,
+];
+const ALL_TYPES = [...PERMITTED_TYPES, ...ILLEGAL_TYPES];
+
 /**
  * either return the appropriate CSS format
  * for a specific font URL, or generate an
@@ -115,8 +129,11 @@ class Font extends EventManager {
      *
      * @param {Buffer} buffer The binary data associated with this font.
      */
-    async fromDataBuffer(buffer, filenameOrUrl) {
-        const type = getFontCSSFormat(filenameOrUrl);
+    async fromDataBuffer(buffer, typeOrPath) {
+        let type = typeOrPath;
+        if (!ALL_TYPES.includes(typeOrPath)) {
+            type = getFontCSSFormat(typeOrPath);
+        }
         this.fontData = new DataView(buffer); // Because we want to enforce Big Endian everywhere
         await this.parseBasicData(type);
         const evt = new Event("load", { font: this });

--- a/Font.js
+++ b/Font.js
@@ -97,9 +97,10 @@ class Font extends EventManager {
      * This is a non-blocking operation.
      *
      * @param {String} url The URL for the font in question
+     * @param {String} ext Force extension, e.g. if URL is a base64 string
      */
-    async loadFont(url) {
-        const type = getFontCSSFormat(url);
+    async loadFont(url, ext) {
+        const type = ext ? getFontCSSFormat(ext) : getFontCSSFormat(url);
         fetch(url)
         .then(response => checkFetchResponseStatus(response) && response.arrayBuffer())
         .then(buffer => this.fromDataBuffer(buffer, type))

--- a/Font.js
+++ b/Font.js
@@ -97,15 +97,15 @@ class Font extends EventManager {
      * This is a non-blocking operation.
      *
      * @param {String} url The URL for the font in question
-     * @param {String} ext Force extension, e.g. if URL is a base64 string
+     * @param {String} filename The filename when URL is a base64 string
      */
-    async loadFont(url, ext) {
-        const type = ext ? getFontCSSFormat(ext) : getFontCSSFormat(url);
+    async loadFont(url, filename) {
+        const type = getFontCSSFormat(filename || url);
         fetch(url)
         .then(response => checkFetchResponseStatus(response) && response.arrayBuffer())
         .then(buffer => this.fromDataBuffer(buffer, type))
         .catch(err => {
-            const evt = new Event(`error`, err, `Failed to load font at ${url}`);
+            const evt = new Event(`error`, err, `Failed to load font at ${filename || url}`);
             this.dispatch(evt);
             if (this.onerror) this.onerror(evt);
         });

--- a/README.md
+++ b/README.md
@@ -57,6 +57,27 @@ myFont.onload = evt => doSomeFontThings(evt);
 myFont.src = `./fonts/SourceCodeVariable-Roman.otf.woff2`;
 ```
 
+You can also pass a base64 string. In that case, you'll have to pass the filename as well, so the font type can de deducted from the extension:
+
+```js
+const myFont = new Font(`Adobe Source Code Pro`);
+
+// Grab file frop drop event or file upload
+const file = e.target.files[0];
+
+// Use FileReader to convert the file it to base64
+const reader = new FileReader();
+reader.readAsDataURL(file);
+
+reader.onload = function() {
+    // Pass the base64 string, and the original filename
+    myFont.loadFont(reader.result, file.name);
+    myFont.onload = e => {
+        // ...
+    };
+};
+```
+
 ## Running this code
 
 I'd recommend using the Node.js `live-server` package (`npm install live-server` after which it's `npx live-server`), which will start up a server _and_ open your browser to the server's index.html page, live-reloading whenever you change things in the code.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ myFont.onload = evt => doSomeFontThings(evt);
 myFont.src = `./fonts/SourceCodeVariable-Roman.otf.woff2`;
 ```
 
-You can also pass a base64 string. In that case, you'll have to pass the filename as well, so the font type can de deducted from the extension:
+You can also pass in a file directly, e.g. using the [HTML Drag and Drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API). In that case, you'll need to use `fromDataBuffer` instead of `loadFont`, and pass the original filename explicity so that the type of font can be determined from the extension:
 
 ```js
 const myFont = new Font(`Adobe Source Code Pro`);
@@ -65,13 +65,13 @@ const myFont = new Font(`Adobe Source Code Pro`);
 // Grab file frop drop event or file upload
 const file = e.target.files[0];
 
-// Use FileReader to convert the file it to base64
+// Use FileReader to, well, read the file
 const reader = new FileReader();
-reader.readAsDataURL(file);
+reader.readAsArrayBuffer(file);
 
 reader.onload = function() {
-    // Pass the base64 string, and the original filename
-    myFont.loadFont(reader.result, file.name);
+    // Pass the buffer, and the original filename
+    myFont.fromDataBuffer(reader.result, file.name);
     myFont.onload = e => {
         // ...
     };
@@ -84,7 +84,7 @@ I'd recommend using the Node.js `live-server` package (`npm install live-server`
 
 Barring that, you can of course use one of the many ways to fire up a quick http server:
 - `http-server` (Node.js package)
-- `python -m SimpleHTTPServer` (when still using python 2.7 - please stop using that btw) 
+- `python -m SimpleHTTPServer` (when still using python 2.7 - please stop using that btw)
 - `python -m http.server` (when using Python 3)
 - `php -S localhost:8000` (if you happen to still have PHP installed)
 - `ruby -run -e httpd . -p 8000` (ruby, obviously)


### PR DESCRIPTION
Opted to pass the ~extension~ filename as extra parameter to `loadFont`, so the code responsible for passing the base64 string to Font.js is responsible for detecting the correct extension (as opposed to Font.js having to figure that out based on some base64 data).

Only `loadFont` is affected, this means loading a font through setting the `src` will not work for base64 strings. I found that acceptable, wonder how you feel about that @Pomax.