### PR TITLE
Fix some CMAP supports() functions

### DIFF
--- a/src/opentype/tables/simple/cmap/format12.js
+++ b/src/opentype/tables/simple/cmap/format12.js
@@ -14,18 +14,12 @@ class Format12 {
 
     supports(charCode) {
         if (charCode.charCodeAt) charCode = charCode.charCodeAt(0);
-        const groups = this.groups;
-        let i = groups.findIndex(s => s.startcharCode > charCode);
-        if (i===0) return false;
-        if (i===-1) i = groups.length;
-        let g = groups[i-1];
-        if (g.endcharCode < charCode) return false;
-        return charCode - g.startcharCode + g.startGlyphID;
+        return this.groups.findIndex(s => s.startCharCode <= charCode && charCode <= s.endCharCode) !== -1
     }
 
     getSupportedCharCodes(preservePropNames=false) {
         if (preservePropNames) return this.groups;
-        return this.groups.map(v => ({ start: v.startCode, end: v.endCode}));
+        return this.groups.map(v => ({ start: v.startCharCode, end: v.endCharCode}));
     }
 }
 

--- a/src/opentype/tables/simple/cmap/format13.js
+++ b/src/opentype/tables/simple/cmap/format13.js
@@ -13,13 +13,7 @@ class Format13 {
 
     supports(charCode) {
         if (charCode.charCodeAt) charCode = charCode.charCodeAt(0);
-        const groups = this.groups;
-        let i = groups.findIndex(s => s.startCharCode > charCode);
-        if (i===0) return false;
-        if (i===-1) i = groups.length;
-        let g = groups[i-1];
-        if (g.endcharCode < charCode) return false;
-        return g.glyphId;
+        return this.groups.findIndex(s => s.startCharCode <= charCode && charCode <= s.endCharCode) !== -1
     }
 
     getSupportedCharCodes(preservePropNames=false) {

--- a/src/opentype/tables/simple/cmap/format4.js
+++ b/src/opentype/tables/simple/cmap/format4.js
@@ -46,13 +46,7 @@ class Format4 {
 
     supports(charCode) {
         if (charCode.charCodeAt) charCode = charCode.charCodeAt(0);
-        const segments = this.segments;
-        let i = segments.findIndex(s => s.start > charCode);
-        if (i===0) return false;
-        if (i===-1) i = segments.length;
-        let s = segments[i-1];
-        if (s.end < charCode) return false;
-        return charCode + s.idDelta;
+        return this.segments.findIndex(s => s.startCode <= charCode && charCode <= s.endCode) !== -1
     }
 
     getSupportedCharCodes(preservePropNames=false) {

--- a/src/opentype/tables/simple/cmap/format8.js
+++ b/src/opentype/tables/simple/cmap/format8.js
@@ -14,18 +14,12 @@ class Format8 {
 
     supports(charCode) {
         if (charCode.charCodeAt) charCode = charCode.charCodeAt(0);
-        const groups = this.groups;
-        let i = groups.findIndex(s => s.startcharCode > charCode);
-        if (i===0) return false;
-        if (i===-1) i = groups.length;
-        let g = groups[i-1];
-        if (g.endcharCode < charCode) return false;
-        return charCode - g.startcharCode + g.startGlyphID;
+        return this.groups.findIndex(s => s.startcharCode <= charCode && charCode <= s.endcharCode) !== -1
     }
 
     getSupportedCharCodes(preservePropNames=false) {
         if (preservePropNames) return this.groups;
-        return this.groups.map(v => ({ start: v.startCode, end: v.endCode}));
+        return this.groups.map(v => ({ start: v.startcharCode, end: v.endcharCode}));
     }
 }
 

--- a/test/test.otf.js
+++ b/test/test.otf.js
@@ -37,7 +37,8 @@ font.onload = () => {
     testSFNT(SFNT);
 
     assertEqual(font.supports('a'), true, `font supports the Latin lowercase A`);
-    assertEqual(font.supports('〆'), true, `font does not support the Japanese EOL marker`);
+    assertEqual(font.supports('Ɔ'), false, `font does not support the Latin capital letter open O`);
+    assertEqual(font.supports('〆'), false, `font does not support the Japanese EOL marker`);
 }
 
 font.src = `../fonts/SourceCodePro-Regular.otf`;

--- a/test/test.ttf.js
+++ b/test/test.ttf.js
@@ -37,7 +37,8 @@ font.onload = () => {
     testSFNT(SFNT, true);
 
     assertEqual(font.supports('a'), true, `font supports the Latin lowercase A`);
-    assertEqual(font.supports('〆'), true, `font does not support the Japanese EOL marker`);
+    assertEqual(font.supports('Ɔ'), false, `font does not support the Latin capital letter open O`);
+    assertEqual(font.supports('〆'), false, `font does not support the Japanese EOL marker`);
 }
 
 font.src = `../fonts/SourceCodePro-Regular.ttf`;


### PR DESCRIPTION
I think the current implementation of some of the CMAP `supports()` functions were basically returning true all the time. I fixed one of them and applied the same fix to the four of them that were using `findIndex()`. I updated a bit the unit tests but nowhere near thoroughly enough.