### PR TITLE
Fix COLR/CPAL color tables

### DIFF
--- a/src/opentype/tables/createTable.js
+++ b/src/opentype/tables/createTable.js
@@ -49,6 +49,10 @@ Promise.all([
     import("./simple/bitmap/CBDT.js"),
     import("./simple/bitmap/sbix.js"),
 
+    // color
+    import("./simple/color/COLR.js"),
+    import("./simple/color/CPAL.js"),
+
     // "other" tables
     import("./simple/other/DSIG.js"),
     import("./simple/other/hdmx.js"),

--- a/src/opentype/tables/simple/color/CPAL.js
+++ b/src/opentype/tables/simple/color/CPAL.js
@@ -1,4 +1,5 @@
 import { SimpleTable } from "../../simple-table.js";
+import lazy from "../../../../lazy.js";
 
 /**
  * The OpenType `CPAL` table.


### PR DESCRIPTION
I noticed I wasn't able to address the COLR/CPAL tables. This PR contains a few fixes, but I wasn't able to address all issues.

While testing [Bungee Color](https://github.com/djrrb/Bungee/blob/master/fonts/Bungee_Color_Fonts/BungeeColor-Regular_colr_Windows.ttf) I found that the tables weren't included in `createTable` ([fixed here](https://github.com/Pomax/Font.js/commit/02b8ec049ede8596c90dbef22cdf504177c13aec)).

The CPAL implementation missed an include ([fix](https://github.com/Pomax/Font.js/commit/a3ee0828702e3497a6a2c19cb1d0fcc2011039a7)), and is now callable. Only the `colorRecord` blue, green, red, alpha values are always 0. So that would need some looking intoing.

COLR has some offsets set as `undefined`:

```
baseGlyphRecordsOffset: undefined
layerRecordsOffset: undefined
numBaseGlyphRecords: 288
numLayerRecords: 0
version: 0
```

I hope this PR will be able to kick-start the more complex fixes 😅 