### PR TITLE
Make fetch available to browser again

### DIFF
--- a/Font.js
+++ b/Font.js
@@ -20,10 +20,12 @@ const ILLEGAL_TYPES = [
 
 const ALL_TYPES = [...PERMITTED_TYPES, ...ILLEGAL_TYPES];
 
-if(typeof globalThis.fetch === "undefined") {
+let fetch = globalThis.fetch;
+
+if(!fetch) {
     let backlog = [];
 
-    var fetch = (...args) => {
+    fetch = (...args) => {
         return new Promise((resolve, reject) => {
             backlog.push({ args, resolve, reject});
         });
@@ -47,8 +49,6 @@ if(typeof globalThis.fetch === "undefined") {
             fetch(...instruction.args).then(data => instruction.resolve(data)).catch(err => instruction.reject(err));
         }
     });
-} else {
-    fetch = globalThis.fetch;
 }
 
 

--- a/Font.js
+++ b/Font.js
@@ -20,7 +20,7 @@ const ILLEGAL_TYPES = [
 
 const ALL_TYPES = [...PERMITTED_TYPES, ...ILLEGAL_TYPES];
 
-if(typeof fetch === "undefined") {
+if(typeof globalThis.fetch === "undefined") {
     let backlog = [];
 
     var fetch = (...args) => {
@@ -47,6 +47,8 @@ if(typeof fetch === "undefined") {
             fetch(...instruction.args).then(data => instruction.resolve(data)).catch(err => instruction.reject(err));
         }
     });
+} else {
+    fetch = globalThis.fetch;
 }
 
 


### PR DESCRIPTION
Since using `globalThis` we need to map fetch from that so we can still use it in the browser. Avoids this error:

![image](https://user-images.githubusercontent.com/4570664/92574202-17ade300-f287-11ea-9f51-de9b1e6549c2.png)
