### PR TITLE
Fix src/opentype/index.js be removed by NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,5 +4,5 @@ protected
 testing
 .gitignore
 index.html
-index.js
+/index.js
 test.js


### PR DESCRIPTION
Hi @Pomax we ran into this issue where our build process could not find `src/opentype/index.js` in Font.js. Turns out it got removed due to the `.npmignore` file that was recently added.

`index.js` in .npmignore applies to all files matching this pattern, while
(I assume) it was meant to only ignore the `index.js` file in the root of
the project.