### PR TITLE
Use correct variable

### DIFF
--- a/src/opentype/tables/advanced/lookups/gsub/lookup-type-6.js
+++ b/src/opentype/tables/advanced/lookups/gsub/lookup-type-6.js
@@ -47,7 +47,7 @@ class LookupType6 extends LookupType {
         ...new Array(this.lookaheadGlyphCount),
       ].map((_) => p.Offset16);
       this.seqLookupCount = p.uint16;
-      this.seqLookupRecords = [...new Array(this.substitutionCount)].map(
+      this.seqLookupRecords = [...new Array(this.seqLookupCount)].map(
         (_) => new SequenceLookupRecord(p)
       );
     }


### PR DESCRIPTION
Another one in the "hmm, doesn't look quite right"-department, this seemed to use a non-existent variable, which would make format 3 lookups wrong!

Built upon #146