### PR TITLE
Format 2

### DIFF
--- a/src/opentype/tables/advanced/lookups/gsub/lookup-type-6.js
+++ b/src/opentype/tables/advanced/lookups/gsub/lookup-type-6.js
@@ -134,7 +134,7 @@ class ChainSubClassSetTable extends ParsedData {
   }
   getSubClass(index) {
     let p = this.parser;
-    p.currentPosition = this.start + this.chainSubRuleOffsets[index];
+    p.currentPosition = this.start + this.chainSubClassRuleOffsets[index];
     return new ChainSubClassRuleTable(p);
   }
 }


### PR DESCRIPTION
I don't know if this'll fully fix https://github.com/Pomax/lib-font/issues/144 but I hope so!

On `master` this will yield `Cannot read properties of undefined (reading '0')`, with this PR it'll report properly. Use this to test before/after:

```javascript
import { Font } from "../../../lib-font.js";
import { readFileSync } from "fs";

const buffer = readFileSync("./fonts/Inter-Regular.otf");
const font = new Font("Inter");
await font.fromDataBuffer(buffer.buffer, "Inter-Regular.otf");

const GSUB = font.opentype.tables.GSUB;
const lookup3 = GSUB.getLookup(3);
const subtable = lookup3.getSubTable(0);
const classSet = subtable.getChainSubClassSet(1);
const roel = classSet.getSubClass(0);

console.log(`substitutionCount: ${roel.substitutionCount}`);
console.log(`substLookupRecords.length: ${roel.substLookupRecords.length}`);
```